### PR TITLE
fix: exclude SQLite temp files from backup to prevent rsync code 24

### DIFF
--- a/startos/backups.ts
+++ b/startos/backups.ts
@@ -1,5 +1,9 @@
 import { sdk } from './sdk'
 
 export const { createBackup, restoreInit } = sdk.setupBackups(
-  async ({ effects }) => sdk.Backups.ofVolumes('main', 'startos'),
+  async ({ effects }) =>
+    sdk.Backups.ofVolumes('main', 'startos').setOptions({
+      // Match all SQLite temp files regardless of database extension (.sqlite, .db, etc.)
+      exclude: ['*-journal', '*-wal', '*-shm'],
+    }),
 )


### PR DESCRIPTION
Fixes #18

## Summary

- Exclude `*-journal`, `*-wal`, and `*-shm` from rsync backup
- These are SQLite-internal temporaries that must never be restored; SQLite recreates them as needed

## Why this fixes it

rsync scans the volume directory, finds a `-journal` or `-wal` file, then the file disappears before rsync can copy it (SQLite committed/checkpointed). The SDK treats any non-zero rsync exit as a fatal error, so code 24 ("files vanished") fails the backup.

The LDK database (`ldk_node_data.sqlite`) triggers this via its `-journal` file. The NWC database (`nwc.db`) already runs in WAL mode — `nwc.db-wal` and `nwc.db-shm` are present on disk and covered by the additional excludes.

## Test plan

- [x] Trigger a backup from the StartOS UI with Alby Hub running
- [x] Confirm backup completes without "rsync exited with code 24" error
- [x] Confirm restore still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)