### PR TITLE
chore: bump start-sdk to 1.5.2 (1.22.2:2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "albyhub-startos",
       "dependencies": {
-        "@start9labs/start-sdk": "1.5.1",
+        "@start9labs/start-sdk": "1.5.2",
         "lnd-startos": "github:Start9Labs/lnd-startos#next"
       },
       "devDependencies": {
@@ -62,9 +62,9 @@
       "license": "MIT"
     },
     "node_modules/@start9labs/start-sdk": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.5.1.tgz",
-      "integrity": "sha512-iztLiOCtHuTfUCd2JOWio4OvBk5qFGa0NI+G+ZB/dQ1sWtunYEnzqMcF6N/Ss4L6+7bBOMAMU4VuhyxeZoHyIw==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.5.2.tgz",
+      "integrity": "sha512-3L4OKuH9kUtuH6G20BSPk85yN/jS3+0WNkP19ahwO9Nc7L6STel4hujvKii3osf0p0tU2q5Mk2Y8b9f2dVR1ng==",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^3.0.0",
@@ -109,9 +109,9 @@
     },
     "node_modules/bitcoin-core-startos": {
       "name": "bitcoin-core",
-      "resolved": "git+ssh://git@github.com/Start9Labs/bitcoin-core-startos.git#c745e4dffc8a9ff3984bd00c1ea9ea843439b74c",
+      "resolved": "git+ssh://git@github.com/Start9Labs/bitcoin-core-startos.git#cfe246bbb5e9806fb4498b02ec9d542452c25b2d",
       "dependencies": {
-        "@start9labs/start-sdk": "1.5.1",
+        "@start9labs/start-sdk": "1.5.2",
         "diskusage": "^1.2.0"
       }
     },
@@ -198,9 +198,9 @@
       }
     },
     "node_modules/lnd-startos": {
-      "resolved": "git+ssh://git@github.com/Start9Labs/lnd-startos.git#0e166a059e2b1768abb6747b34780d52c160ad26",
+      "resolved": "git+ssh://git@github.com/Start9Labs/lnd-startos.git#eff043e4c6662f35a3b0065e8836bacec04baf0f",
       "dependencies": {
-        "@start9labs/start-sdk": "1.5.1",
+        "@start9labs/start-sdk": "1.5.2",
         "bitcoin-core-startos": "github:Start9Labs/bitcoin-core-startos#next/28.x",
         "mime": "^4.0.7",
         "rfc4648": "1.5.4"
@@ -389,7 +389,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@start9labs/start-sdk": "1.5.1",
+    "@start9labs/start-sdk": "1.5.2",
     "lnd-startos": "github:Start9Labs/lnd-startos#next"
   },
   "devDependencies": {

--- a/startos/versions/index.ts
+++ b/startos/versions/index.ts
@@ -1,7 +1,7 @@
 import { VersionGraph } from '@start9labs/start-sdk'
-import { v_1_22_2_1 } from './v1.22.2.1'
+import { v_1_22_2_2 } from './v1.22.2.2'
 
 export const versionGraph = VersionGraph.of({
-  current: v_1_22_2_1,
+  current: v_1_22_2_2,
   other: [],
 })

--- a/startos/versions/v1.22.2.2.ts
+++ b/startos/versions/v1.22.2.2.ts
@@ -4,24 +4,14 @@ import { join } from 'path'
 import { storeJson } from '../fileModels/store.json'
 import { sdk } from '../sdk'
 
-export const v_1_22_2_1 = VersionInfo.of({
-  version: '1.22.2:1',
+export const v_1_22_2_2 = VersionInfo.of({
+  version: '1.22.2:2',
   releaseNotes: {
-    en_US: `**Internal**
-
-- Bump start-sdk to 1.5.0.`,
-    es_ES: `**Interno**
-
-- Actualización de start-sdk a 1.5.0.`,
-    de_DE: `**Intern**
-
-- start-sdk auf 1.5.0 aktualisiert.`,
-    pl_PL: `**Wewnętrzne**
-
-- Aktualizacja start-sdk do wersji 1.5.0.`,
-    fr_FR: `**Interne**
-
-- Mise à jour de start-sdk vers 1.5.0.`,
+    en_US: 'Bumps start-sdk → 1.5.2.',
+    es_ES: 'Actualiza start-sdk → 1.5.2.',
+    de_DE: 'Aktualisiert start-sdk → 1.5.2.',
+    pl_PL: 'Aktualizuje start-sdk → 1.5.2.',
+    fr_FR: 'Met à jour start-sdk → 1.5.2.',
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

- Bumps `@start9labs/start-sdk` from 1.5.1 → 1.5.2 (release: 1.22.2:1 → 1.22.2:2).
- Upstream Alby Hub remains at v1.22.2 (latest).

The SDK 1.5.2 release only fixes `Backups.withPgDump` / `Backups.withMysqlDump`, which this package does not use, so no code adaptations were needed.

## Test plan

- [x] `make` builds clean .s9pk artifacts for x86_64 and aarch64.