### PR TITLE
chore: bump Alby Hub to 1.24.0; 1.23.0:6 → 1.24.0:0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1576,17 +1576,17 @@
       "license": "MIT"
     },
     "node_modules/bitcoin-core-startos": {
-      "resolved": "git+ssh://git@github.com/Start9Labs/bitcoin-core-startos.git#4f8dff85044df9c6ce1179f7a6090ee648c54ae8",
+      "resolved": "git+ssh://git@github.com/Start9Labs/bitcoin-core-startos.git#eea170b29f5e39c813bd8ec6fd604b1f0dc10cad",
       "dependencies": {
-        "@start9labs/start-sdk": "2.0.7",
+        "@start9labs/start-sdk": "2.0.9",
         "diskusage": "^1.2.0",
         "tor-startos": "github:Start9Labs/tor-startos#next"
       }
     },
     "node_modules/cln-startos": {
-      "resolved": "git+ssh://git@github.com/Start9Labs/cln-startos.git#16b3466ff03c0f75ff09f689fc5b1fd0c7851d12",
+      "resolved": "git+ssh://git@github.com/Start9Labs/cln-startos.git#98c680ab7d7e6081d5735de3f4954c1e03f30691",
       "dependencies": {
-        "@start9labs/start-sdk": "2.0.7",
+        "@start9labs/start-sdk": "2.0.9",
         "bitcoin-core-startos": "github:Start9Labs/bitcoin-core-startos#next/28.x",
         "dotenv": "^17.2.0",
         "node-forge": "^1.3.1",
@@ -1688,9 +1688,9 @@
       }
     },
     "node_modules/lnd-startos": {
-      "resolved": "git+ssh://git@github.com/Start9Labs/lnd-startos.git#7881e414558146b8ab8325016d95af4c36dd8b4b",
+      "resolved": "git+ssh://git@github.com/Start9Labs/lnd-startos.git#5049662023bc1860090ba6ac12a5379d3a390bfe",
       "dependencies": {
-        "@start9labs/start-sdk": "2.0.7",
+        "@start9labs/start-sdk": "2.0.9",
         "bitcoin-core-startos": "github:Start9Labs/bitcoin-core-startos#next/28.x",
         "mime": "^4.0.7",
         "rfc4648": "1.5.4",
@@ -1772,7 +1772,7 @@
       }
     },
     "node_modules/phoenixd-startos": {
-      "resolved": "git+ssh://git@github.com/Start9-Community/phoenixd-startos.git#d16053fa2b268294bc6fd317dbe486e101a42ad8",
+      "resolved": "git+ssh://git@github.com/Start9-Community/phoenixd-startos.git#2b79184cf4703e9f9b99a635b5cf5a8e706568f8",
       "dependencies": {
         "@start9labs/start-sdk": "2.0.7"
       }
@@ -1815,7 +1815,7 @@
       }
     },
     "node_modules/tor-startos": {
-      "resolved": "git+ssh://git@github.com/Start9Labs/tor-startos.git#e3e2b53a84cb92855ac7b35764df288fab1fa333",
+      "resolved": "git+ssh://git@github.com/Start9Labs/tor-startos.git#aa867cfea0f20095feb56e96cad3510393d912de",
       "dependencies": {
         "@noble/curves": "*",
         "@start9labs/start-sdk": "2.0.7",

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -14,7 +14,7 @@ export const manifest = setupManifest({
   images: {
     albyhub: {
       source: {
-        dockerTag: 'ghcr.io/getalby/hub:v1.23.0',
+        dockerTag: 'ghcr.io/getalby/hub:v1.24.0',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,23 +1,98 @@
 import { VersionInfo } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '1.23.0:6',
+  version: '1.24.0:0',
   releaseNotes: {
-    en_US: `Keeps the its Lightning backend connection working when its Lightning backend changes how it serves TLS.
+    en_US: `Updates Alby Hub to 1.24.0.
 
-Alby Hub resolved its Lightning backend's address from a field that is only populated for one of the two ways a service can publish a port. It now reads the address itself, which is correct either way — so the connection survives its Lightning backend's next update instead of going unreachable.`,
-    es_ES: `Mantiene la conexión con its Lightning backend cuando its Lightning backend cambia su forma de servir TLS.
+**Security**
 
-Alby Hub resolvía la dirección de its Lightning backend a partir de un campo que solo se rellena en una de las dos formas en que un servicio puede publicar un puerto. Ahora lee la dirección en sí, que es correcta en ambos casos, así que la conexión sobrevive a la próxima actualización de its Lightning backend en lugar de quedar inaccesible.`,
-    de_DE: `Hält die its Lightning backend-Verbindung aufrecht, wenn its Lightning backend die Art der TLS-Bereitstellung ändert.
+- The swaps, mnemonic, and log endpoints now require a full-access API key.
+- Backup restore can no longer write outside the restore directory.
+- Redirect URLs are validated, request bodies are kept out of error logs, empty unlock passwords are rejected, and unlock attempts are rate limited globally rather than per IP.
 
-Alby Hub ermittelte die Adresse von its Lightning backend aus einem Feld, das nur bei einer der beiden Arten gefüllt ist, auf die ein Dienst einen Port veröffentlichen kann. Jetzt wird die Adresse selbst gelesen, die in beiden Fällen stimmt — die Verbindung übersteht damit das nächste its Lightning backend-Update, statt unerreichbar zu werden.`,
-    pl_PL: `Utrzymuje połączenie z its Lightning backend, gdy its Lightning backend zmienia sposób udostępniania TLS.
+**Features**
 
-Alby Hub ustalał adres its Lightning backend na podstawie pola wypełnianego tylko przy jednym z dwóch sposobów publikowania portu przez usługę. Teraz odczytuje sam adres, poprawny w obu przypadkach — dzięki temu połączenie przetrwa kolejną aktualizację its Lightning backend, zamiast stać się nieosiągalne.`,
-    fr_FR: `Maintient la connexion à its Lightning backend lorsque its Lightning backend change sa façon de servir TLS.
+- Filter the transaction list, receive invoices to connected apps, and a refreshed payment QR and status display.
 
-Alby Hub déterminait l'adresse de its Lightning backend à partir d'un champ renseigné dans un seul des deux modes de publication d'un port par un service. Il lit désormais l'adresse elle-même, correcte dans les deux cas — la connexion survit donc à la prochaine mise à jour de its Lightning backend au lieu de devenir injoignable.`,
+**Fixes**
+
+- phoenixd invoice lookup falls back to outgoing payments.
+- Bark support updated for the mandatory Bark SDK upgrade.
+
+Full release notes: https://github.com/getAlby/hub/releases/tag/v1.24.0`,
+    es_ES: `Actualiza Alby Hub a 1.24.0.
+
+**Seguridad**
+
+- Los endpoints de swaps, frase mnemotécnica y registros ahora requieren una clave de API con acceso completo.
+- La restauración de copias de seguridad ya no puede escribir fuera del directorio de restauración.
+- Se validan las URL de redirección, los cuerpos de las peticiones se excluyen de los registros de error, se rechazan las contraseñas de desbloqueo vacías y el límite de intentos de desbloqueo ahora es global en lugar de por IP.
+
+**Novedades**
+
+- Filtrado de la lista de transacciones, recepción de facturas en las aplicaciones conectadas y nueva presentación del QR y del estado de pago.
+
+**Correcciones**
+
+- La búsqueda de facturas de phoenixd recurre a los pagos salientes.
+- Se actualiza la compatibilidad con Bark por la actualización obligatoria del SDK de Bark.
+
+Notas completas de la versión: https://github.com/getAlby/hub/releases/tag/v1.24.0`,
+    de_DE: `Aktualisiert Alby Hub auf 1.24.0.
+
+**Sicherheit**
+
+- Die Endpunkte für Swaps, Mnemonic und Logs erfordern jetzt einen API-Schlüssel mit Vollzugriff.
+- Die Backup-Wiederherstellung kann nicht mehr außerhalb des Wiederherstellungsverzeichnisses schreiben.
+- Weiterleitungs-URLs werden validiert, Anfrage-Inhalte erscheinen nicht mehr in Fehlerprotokollen, leere Entsperrkennwörter werden abgelehnt und Entsperrversuche werden global statt pro IP begrenzt.
+
+**Funktionen**
+
+- Filtern der Transaktionsliste, Empfang von Rechnungen in verbundenen Apps sowie überarbeitete Darstellung von Zahlungs-QR-Code und -Status.
+
+**Fehlerbehebungen**
+
+- Die phoenixd-Rechnungssuche greift auf ausgehende Zahlungen zurück.
+- Bark-Unterstützung an das verpflichtende Bark-SDK-Update angepasst.
+
+Vollständige Versionshinweise: https://github.com/getAlby/hub/releases/tag/v1.24.0`,
+    pl_PL: `Aktualizuje Alby Hub do 1.24.0.
+
+**Bezpieczeństwo**
+
+- Punkty końcowe swapów, frazy mnemonicznej i dzienników wymagają teraz klucza API z pełnym dostępem.
+- Przywracanie kopii zapasowej nie może już zapisywać poza katalogiem przywracania.
+- Adresy przekierowań są weryfikowane, treści żądań nie trafiają do dzienników błędów, puste hasła odblokowujące są odrzucane, a limit prób odblokowania działa globalnie zamiast na adres IP.
+
+**Nowości**
+
+- Filtrowanie listy transakcji, odbieranie faktur w podłączonych aplikacjach oraz odświeżony widok kodu QR i statusu płatności.
+
+**Poprawki**
+
+- Wyszukiwanie faktur w phoenixd korzysta zapasowo z płatności wychodzących.
+- Obsługa Bark dostosowana do obowiązkowej aktualizacji SDK Bark.
+
+Pełne informacje o wydaniu: https://github.com/getAlby/hub/releases/tag/v1.24.0`,
+    fr_FR: `Met à jour Alby Hub vers 1.24.0.
+
+**Sécurité**
+
+- Les points d'accès pour les swaps, la phrase mnémonique et les journaux exigent désormais une clé d'API à accès complet.
+- La restauration de sauvegarde ne peut plus écrire en dehors du répertoire de restauration.
+- Les URL de redirection sont validées, le corps des requêtes est exclu des journaux d'erreurs, les mots de passe de déverrouillage vides sont refusés et les tentatives de déverrouillage sont limitées globalement plutôt que par IP.
+
+**Fonctionnalités**
+
+- Filtrage de la liste des transactions, réception de factures dans les applications connectées et nouvel affichage du QR code et du statut de paiement.
+
+**Corrections**
+
+- La recherche de factures phoenixd bascule sur les paiements sortants.
+- Prise en charge de Bark mise à jour pour la mise à niveau obligatoire du SDK Bark.
+
+Notes de version complètes : https://github.com/getAlby/hub/releases/tag/v1.24.0`,
   },
   migrations: {},
 })


### PR DESCRIPTION
## Summary

Bumps Alby Hub from **1.23.0** to **1.24.0** ([upstream release](https://github.com/getAlby/hub/releases/tag/v1.24.0)), and ships as StartOS version **1.23.0:6 → 1.24.0:0**.

The pinned image `ghcr.io/getalby/hub:v1.24.0` was verified to resolve before pinning — its OCI index publishes `linux/amd64` and `linux/arm64`, matching the manifest's declared archs.

## Upstream highlights

**Security** — a fair amount of hardening this release:

- Swaps, mnemonic, and log endpoints now require a full-access API key (getAlby/hub#2473, #2537).
- Backup restore can no longer write outside the restore directory (#2529).
- `return_to` redirect URLs are validated (#2532); request bodies removed from error logs (#2533); raw postgres error details no longer leak in duplicate-key responses (#2538).
- Legacy acceptance of an empty unlock password removed (#2534); the unlock rate limiter is now global rather than per-IP (#2540); node migration files use an updated encryption scheme (#2539).

**Features** — transaction list filtering (#2464), receiving invoices to apps (#2466), refreshed payment QR and status components (#2459), and in-app migration from postgres to sqlite (#2524).

**Fixes relevant to the backends this package supports** — phoenixd `LookupInvoice` now falls back to outgoing payments (#2447), and Bark onboarding/migration/settlement was updated for the mandatory Bark SDK upgrade (#2502, #2523). LND's client library moved 0.20.1-beta → 0.21.1-beta (#2402, #2517), which is already within this package's `>=0.21.1-beta:4` dependency range.

## What else rode along

- Refreshed the `*-startos` git dependencies (`bitcoin-core`, `cln`, `lnd`, `phoenixd`, `tor`). This carries their own `@start9labs/start-sdk` pins from 2.0.7 to 2.0.9 — matching this package's root pin, so the `overrides` block collapses them to a single hoisted SDK copy (verified: exactly one `@start9labs/start-sdk` in `node_modules`).
- No `@start9labs/start-sdk` bump — the pin is already at npm's latest, 2.0.9.
- No migration needed. The postgres → sqlite work upstream is an in-app flow, not StartOS state; nothing in this package's store or volume layout changes.
- No package code changes were required; nothing in the release breaks the interfaces this package binds against.

## Test plan

- `npm run check` (tsc) — green.
- `prettier --check` on the touched files — clean.
- Lockfile converged to a fixed point (repeated `npm install` is byte-stable); the diff is confined to the five git-dep SHAs and their SDK pins.
- `1.24.0:0` confirmed free on the registry — production currently publishes `1.23.0:6`, so this is the next revision and does not collide with anything `master` has shipped.

Per the monitor cycle, this ships on a green typecheck; `make` / s9pk verification is left to review.
